### PR TITLE
Set defaults for ecr-repo and ecr-tag

### DIFF
--- a/actions/build-push-ecr/README.md
+++ b/actions/build-push-ecr/README.md
@@ -16,9 +16,9 @@ pushes the docker image to the ECR repo.
       with:
         aws-role-to-assume: arn:aws:iam::123456789012:role/my-gh-repo-role
         aws-region: us-east-1
-        ecr-repo: my-ecr-repo
-        ecr-tag: 0.0.1
-        dockerfile: ./Dockerfile
+        ecr-repo: <DEFAULTS TO CURRENT REPO NAME>
+        ecr-tag: <DEFAULTS TO CURRENT GIT TAG>
+        docker-build-args: <DEFAULTS TO "-f ./Dockerfile .">
 ```
 
 # Depends

--- a/actions/build-push-ecr/action.yml
+++ b/actions/build-push-ecr/action.yml
@@ -14,11 +14,11 @@ inputs:
     description: 'AWS region'
     required: true
   ecr-repo:
-    description: 'ECR repo name'
-    required: true
+    description: 'ECR repo name. Defaults to GH repo name.'
+    required: false
   ecr-tag:
-    description: 'ECR tag'
-    required: true
+    description: 'ECR tag. Defaults to current tag.'
+    required: false
   docker-build-args:
     description: 'Args passed to docker build'
     required: false
@@ -31,6 +31,25 @@ outputs:
 runs:
   using: "composite"
   steps:
+  ## REPO
+  # it is not ok to use "set-env"
+  # https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
+  - name: set REPO
+    shell: bash
+    run: |
+      [ ! -z "${{ inputs.ecr-repo }}" ] \
+        && echo "REPO=${{ inputs.ecr-repo }}" \
+        || echo "REPO=$(echo $GITHUB_REPOSITORY | cut -d/ -f2)" \
+      >> $GITHUB_ENV
+  ## TAG
+  - name: set TAG
+    shell: bash
+    run: |
+      [ ! -z "${{ inputs.ecr-tag }}" ] \
+        && echo "TAG=${{ inputs.ecr-tag }}" \
+        || echo "TAG=${GITHUB_REF/refs\/tags\//}" \
+      >> $GITHUB_ENV
+  ##
   - name: Assume AWS role
     if: ${{ inputs.aws-role-to-assume }}
     uses: aws-actions/configure-aws-credentials@v1.6.0
@@ -51,7 +70,7 @@ runs:
     id: build-push
     shell: bash
     env:
-      ECR_IMAGE: "${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr-repo }}:${{ inputs.ecr-tag }}"
+      ECR_IMAGE: "${{ steps.login-ecr.outputs.registry }}/${{ env.REPO }}:${{ env.TAG }}"
     run: |
       docker build -t $ECR_IMAGE ${{ inputs.docker-build-args }}
       docker push $ECR_IMAGE


### PR DESCRIPTION
`ecr-repo` and `ecr-tag` inputs  are now defaults to git repo and git tag respectively.